### PR TITLE
Make music service not sticky so that android won't start service by …

### DIFF
--- a/android/src/main/java/com/guichaguri/trackplayer/service/MusicService.java
+++ b/android/src/main/java/com/guichaguri/trackplayer/service/MusicService.java
@@ -112,7 +112,7 @@ public class MusicService extends HeadlessJsTaskService {
         handler = new Handler();
 
         super.onStartCommand(intent, flags, startId);
-        return START_STICKY;
+        return START_NOT_STICKY;
     }
 
     @Override


### PR DESCRIPTION
…itself when there is no React context yet.

That caused crash with "Module AppRegistry is not a registered callable module (calling startHeadlessTask)" error